### PR TITLE
Session read handler must always return a string

### DIFF
--- a/CacheBackend.php
+++ b/CacheBackend.php
@@ -93,7 +93,7 @@ class CacheBackend extends BaseAdapter implements AdapterInterface {
      */
     public function _read($id)
     {
-        return $this->read_cache[$id] = $this->backend->get($id);
+        return $this->read_cache[$id] = (string)$this->backend->get($id);
     }
 
     /**


### PR DESCRIPTION
PHP internals in 7.0+ require that the session read handler return a string at all times: https://bugs.php.net/bug.php?id=71187 . Many other projects were hit by this change, including Zend: https://github.com/netiul/zend-session/commit/2eab602a7b1e164654ecca8a0c4391041069a125 . Simply forcing the return value to be a string fixes a bug where calling `$session->regenerateId()` causes a fatal error.
